### PR TITLE
AMP 95 - Draggable Popup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "fuse.js": "^7.1.0",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-draggable": "^4.5.0"
       },
       "devDependencies": {
         "@babel/core": "^7.27.0",
@@ -4117,6 +4118,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -6771,6 +6781,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -7185,6 +7204,23 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -7247,6 +7283,20 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-draggable": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.5.0.tgz",
+      "integrity": "sha512-VC+HBLEZ0XJxnOxVAZsdRi8rD04Iz3SiiKOoYzamjylUcju/hP9np/aZdLHf/7WOD268WMoNJMvYfB5yAK45cw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
       }
     },
     "node_modules/react-is": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "fuse.js": "^7.1.0",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-draggable": "^4.5.0"
       },
       "devDependencies": {
         "@babel/core": "^7.27.0",
@@ -4112,6 +4113,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -6767,6 +6777,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -7181,6 +7200,23 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -7241,6 +7277,20 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-draggable": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.5.0.tgz",
+      "integrity": "sha512-VC+HBLEZ0XJxnOxVAZsdRi8rD04Iz3SiiKOoYzamjylUcju/hP9np/aZdLHf/7WOD268WMoNJMvYfB5yAK45cw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "dependencies": {
     "fuse.js": "^7.1.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-draggable": "^4.5.0"
   }
 }

--- a/scripts/prof_names.json
+++ b/scripts/prof_names.json
@@ -18,7 +18,7 @@
   "Chen,N.N.": "https://campusdirectory.ucsc.edu/cd_detail?uid=nchen",
   "Ramirez,R.K.": "https://campusdirectory.ucsc.edu/cd_detail?uid=renya",
   "Kramer,A.L.": "https://campusdirectory.ucsc.edu/cd_detail?uid=alk",
-  "Hernandez, J": "https://campusdirectory.ucsc.edu/cd_detail?uid=ghern112",
+  "Hernandez,G.": "https://campusdirectory.ucsc.edu/cd_detail?uid=ghern112",
   "Daehnke,J.D.": "https://campusdirectory.ucsc.edu/cd_detail?uid=jdaehnke",
   "Anderson,M.D.": "https://campusdirectory.ucsc.edu/cd_detail?uid=mda",
   "Miller,D.P.": "https://campusdirectory.ucsc.edu/cd_detail?uid=dpmiller",

--- a/src/background/ampCache.js
+++ b/src/background/ampCache.js
@@ -6,7 +6,7 @@
 
 // --- Constants ---
 const CAMPUS_DIRECTORY_BASE_URL = "https://campusdirectory.ucsc.edu/api/uid/";
-const CACHE_DURATION_MS = 24 * 60 * 60 * 1000; // 24 hours
+const CACHE_DURATION_MS = 24 * 60 * 60 * 1000 * 7; // 1 week
 
 /**
  * Fetches profile data directly from the campus directory API.

--- a/src/background/rmpCache.js
+++ b/src/background/rmpCache.js
@@ -9,7 +9,7 @@ import Fuse from "fuse.js";
 // --- Constants ---
 const RATE_MY_PROFESSORS_ENDPOINT = "https://www.ratemyprofessors.com/graphql";
 const UCSC_SCHOOL_ID = "U2Nob29sLTEwNzg="; // Base64 encoded "School-1078"
-const CACHE_DURATION_MS = 24 * 60 * 60 * 1000; // 24 hours
+const CACHE_DURATION_MS = 24 * 60 * 60 * 1000 * 7; // 1 week
 let hasLoggedSuccessfulRmpConnection = false;
 
 // GraphQL query for RateMyProfessors

--- a/src/content/content.js
+++ b/src/content/content.js
@@ -76,34 +76,76 @@ function getProfNameInCart(panel) {
 }
 
 //Modularized this and other parts to reduce repetition for shopping cart B.C.
+/**
+ * Resolves a professor's UID from a dataset using Exact and Fuzzy matching.
+ * Strategy:
+ * 1. Checks for exact key match.
+ * 2. If not found, attempts to match 'Last, F.' pattern against keys like 'Last, F.M.'
+ * @param {string} name - The name from the webpage (e.g., "Jullig,R.").
+ * @param {object} dataset - The dictionary of names to UIDs/URLs (from prof_uids.json).
+ * @returns {string} The resolved UID string (e.g. "rjullig"), or "jdoe" if not found.
+ */
 function getUIDFromJson(name) {
   let uID = "jdoe";
+  // try exact match first
+  let value = data[name];
 
-  // 1. Clean the name (remove extra spaces)
-  const cleanName = name.trim();
+  // if exact match fails, try fuzzy match
+  if (!value) {
+    try {
+      // Split input "Jullig, R." -> "jullig", "r"
+      const nameParts = name.split(",");
+      if (nameParts.length >= 2) {
+        const targetLast = nameParts[0].trim().toLowerCase(); // "jullig"
+        const targetFirstInitial = nameParts[1].trim().charAt(0).toLowerCase(); // "r"
 
-  // 2. Try Exact Match
-  let match = data[cleanName];
+        // search keys: find "jullig r"
+        const matchKey = Object.keys(data).find((key) => {
+          const keyParts = key.split(",");
+          if (keyParts.length < 2) return false;
 
-  // 3. If not found, try UpperCase (Common in legacy databases)
-  if (!match) {
-    match = data[cleanName.toUpperCase()];
+          const keyLast = keyParts[0].trim().toLowerCase();
+          const keyFirstInitial = keyParts[1].trim().charAt(0).toLowerCase();
+
+          // returns only if "juillig" and "r" matches with the key in the JSON file exactly
+          return (
+            targetLast === keyLast && targetFirstInitial === keyFirstInitial
+          );
+        });
+
+        if (matchKey) {
+          console.log(
+            `Fuzzy matched input '${name}' to JSON key '${matchKey}'`,
+          );
+          value = data[matchKey];
+        }
+      }
+    } catch (err) {
+      console.error("Error during fuzzy matching:", err);
+    }
   }
 
-  if (match) {
-    const value = String(match);
-    const uidMatch = value.match(/uid=([\w-]+)/);
+  // process the found value (if any)
+  if (value) {
+    const stringValue = String(value); // e.g. "https://...uid=rjullig"
+
+    // use regex to find 'uid=' and capture what's after it
+    const uidMatch = stringValue.match(/uid=([\w-]+)/);
 
     if (uidMatch && uidMatch[1]) {
+      // found a match, e.g., uidMatch[1] is "rjullig"
       uID = uidMatch[1];
-    } else if (!value.includes("http")) {
-      uID = value;
+    } else if (!stringValue.includes("http")) {
+      // fallback: The value might already be a clean UID
+      uID = stringValue;
+    } else {
+      // the value was a bad URL or something we couldn't parse
+      console.log(`Found invalid UID value for ${name}: ${stringValue}`);
     }
   } else {
-    console.log(
-      `Couldn't match name to uID in the json for name: "${cleanName}"`,
-    );
+    console.log(`Couldn't match name to uID in the json for name: ${name}`);
   }
+
   return uID;
 }
 

--- a/src/react/components/ProfInfoButton.jsx
+++ b/src/react/components/ProfInfoButton.jsx
@@ -486,7 +486,7 @@ export default function ProfInfoButton(props) {
                         onClick={handleToggleMoreInfo}
                         type="button"
                       >
-                        {showMoreInfo ? "Show Less ▼" : "More Info ▶"}
+                        {showMoreInfo ? "Show Less ▼" : "More Info ▲"}
                       </button>
                     )}
 

--- a/src/react/components/ProfInfoButton.jsx
+++ b/src/react/components/ProfInfoButton.jsx
@@ -1,4 +1,6 @@
-import React, { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
+import { createPortal } from "react-dom";
+import Draggable from "react-draggable";
 import "../styles/index.css";
 import {
   getFirst,
@@ -9,17 +11,33 @@ import {
   StarRating,
 } from "../../utils/utils";
 
-export default function ProfInfoButton(props) {
-  // Track whether popup is open or closed
-  const [isOpen, setIsOpen] = useState(false);
-  const [isPhoto, setIsPhoto] = useState("");
-  const [showMoreInfo, setShowMoreInfo] = useState(false);
+// track the highest Z-Index across all professor buttons
+// ensures that the most recently clicked card always pops to the front  - E.H
+if (typeof window.AMP_Z_INDEX === "undefined") {
+  window.AMP_Z_INDEX = 10000;
+}
 
+// active card registry: prevents duplicates
+if (typeof window.AMP_ACTIVE_CARDS === "undefined") {
+  window.AMP_ACTIVE_CARDS = {};
+}
+
+export default function ProfInfoButton(props) {
+  // --- STATES ---
+  const [isOpen, setIsOpen] = useState(false); // for the open/close functionality of info button
+  const [isPhoto, setIsPhoto] = useState(""); // for the professor profile pic
+  const [showMoreInfo, setShowMoreInfo] = useState(false); // for more info button
+  const [isDraggable, setIsDraggable] = useState(false); // dragging state (default = locked)
+  const [zIndex, setZIndex] = useState(window.AMP_Z_INDEX); // local z-index state for popup placement
+  const [spawnPos, setSpawnPos] = useState({ x: 0, y: 0 }); // local state to store where the modal should appear
+  const nodeRef = useRef(null); // Ref required for draggable in React StrictMode
+
+  // --- DATA PROCESSING ---
   const localResearchTopic = props.localResearchTopic;
   const localClassesTaught = props.localClassesTaught;
+  const rateMyProfessor = props.rateMyProfessor;
 
   // rate my professor data - I.K
-  const rateMyProfessor = props.rateMyProfessor;
   const rating = rateMyProfessor?.avgRatingRounded;
   const numRatings = rateMyProfessor?.numRatings;
   const wouldTakeAgain = rateMyProfessor?.wouldTakeAgainPercentRounded;
@@ -37,7 +55,7 @@ export default function ProfInfoButton(props) {
   const roundedDifficulty = roundToOneDecimal(avgDifficulty);
   const roundedWouldTakeAgain = roundToWhole(wouldTakeAgain);
 
-  // --- Process Campus Directory Data ---
+  // Campus Directory Data
   const name = getFirst(props.apiData?.cn) || "Not Listed";
   const email = getFirst(props.apiData?.mail);
   const phone = getFirst(props.apiData?.telephonenumber);
@@ -62,16 +80,23 @@ export default function ProfInfoButton(props) {
     department &&
     normalize(divisionValue) !== normalize(department);
 
+  // global id for global registry
+  const profId = name;
+
+  // --- HELPERS ---
+
   // Shorten long URLs for display
   const formatLinkLabel = (url) => {
     try {
       const u = new URL(url);
       const host = u.hostname.replace("www.", ""); // remove www.
       let path = u.pathname;
+
       // shorten long paths
       if (path.length > 20) {
         path = path.slice(0, 20) + "...";
       }
+
       return `${host}${path}`;
     } catch {
       return "Link"; // fallback
@@ -120,6 +145,7 @@ export default function ProfInfoButton(props) {
     phone && { label: "Phone", value: phone, href: `tel:${phone}` },
   ].filter(Boolean);
 
+  // Items hidden in "More Info"
   const detailItems = [
     website && {
       label: "Website",
@@ -159,62 +185,132 @@ export default function ProfInfoButton(props) {
     }
   }, [props.apiData]); // This function now only changes if apiData changes
 
-  /**
-   * Handles opening and closing of pop up - I.K
-   * Also resets the "Show More" toggle when closing.  - E.H
-   */
-  function handleOpen() {
-    setIsOpen((prev) => !prev);
-    if (isOpen) {
-      setShowMoreInfo(false);
-    }
-  }
+  // function to bring this specific card to the front
+  const bringToFront = useCallback(() => {
+    window.AMP_Z_INDEX += 1;
+    setZIndex(window.AMP_Z_INDEX);
+  }, []);
+
+  // logic specifically for closing
+  const handleClose = (e) => {
+    e.stopPropagation();
+    setIsOpen(false);
+  };
 
   /**
    * Toggles the "More Info" collapsible section.
    */
   function handleToggleMoreInfo(e) {
-    // Stop the click from closing the whole modal
-    // if the button is ever inside the click overlay  - E.H
     e.stopPropagation();
     setShowMoreInfo((prev) => !prev);
   }
 
+  // toggle lock/unlock for dragging
+  const toggleDraggable = (e) => {
+    e.stopPropagation();
+    setIsDraggable((prev) => !prev);
+  };
+
   /**
    * Effect hook to load the professor's photo only when the modal is opened and we have data.  - E.H
+   * Also handles which popup appears depending on what the user clicks on
    */
   useEffect(() => {
     if (isOpen) {
       handlePhotoURL();
+      window.AMP_ACTIVE_CARDS[profId] = bringToFront;
     }
-  }, [isOpen, handlePhotoURL]); // Runs when 'isOpen' or 'handlePhotoURL' changes
 
-  function handleOverlayClick(event) {
-    if (event.target === event.currentTarget) {
-      setIsOpen(false);
-      setShowMoreInfo(false); // also reset on overlay click
+    // clean up
+    return () => {
+      if (isOpen && window.AMP_ACTIVE_CARDS[profId] === bringToFront) {
+        delete window.AMP_ACTIVE_CARDS[profId];
+      }
+    };
+  }, [isOpen, handlePhotoURL, bringToFront, profId]); // runs when any of these change
+
+  // opening logic for the info button
+  const handleInfoClick = (e) => {
+    // get viewport dimensions
+    const vw = Math.max(
+      document.documentElement.clientWidth || 0,
+      window.innerWidth || 0,
+    );
+    const vh = Math.max(
+      document.documentElement.clientHeight || 0,
+      window.innerHeight || 0,
+    );
+
+    // get button position
+    const btn = e.currentTarget.getBoundingClientRect();
+
+    // define card dimensions
+    const CARD_W = 360;
+    const CARD_H = 550;
+    const GAP = 12;
+
+    // calculate X (Horizontal)
+    let finalX = btn.right + GAP; // Try placing to the right first
+
+    // Check if it goes off the right edge
+    if (finalX + CARD_W > vw) {
+      // try placing to the left
+      finalX = btn.left - CARD_W - GAP;
     }
-  }
+
+    // check if it goes off the left edge (e.g., mobile screen)
+    if (finalX < 0) {
+      // if screen is too narrow for offsets, roughly center it
+      finalX = (vw - CARD_W) / 2;
+      // make sure it doesn't go negative even after centering attempts
+      if (finalX < 10) finalX = 10;
+    }
+
+    // calculate Y (Vertical)
+    let finalY = btn.top;
+
+    // check if it goes off the bottom edge
+    if (finalY + CARD_H > vh) {
+      // shift it up so the bottom rests near the window bottom
+      finalY = vh - CARD_H - GAP;
+    }
+
+    // check if it goes off the top edge
+    if (finalY < 10) finalY = 10;
+
+    setSpawnPos({ x: finalX, y: finalY });
+
+    // check if any card for this prof is already open
+    if (window.AMP_ACTIVE_CARDS[profId]) {
+      // if so, bring that card to front
+      window.AMP_ACTIVE_CARDS[profId]();
+      return;
+    }
+
+    // otherwise, open this specific instance
+    if (!isOpen) {
+      setIsOpen(true);
+      setShowMoreInfo(false);
+      setIsDraggable(false);
+    }
+
+    // register immediately so the very next click knows about it
+    window.AMP_ACTIVE_CARDS[profId] = bringToFront;
+    bringToFront();
+  };
 
   // This component won't render anything if it doesn't get apiData
   if (!props.apiData) {
     return null;
   }
 
-  // When the modal is open, we add the 'prof-is-open' class to the
-  // main container. This gives it a higher z-index (1001)
-  // so it appears *above* the overlay and all other buttons.  - E.H
-  const containerClass = isOpen
-    ? "prof-info-container prof-is-open"
-    : "prof-info-container";
-
   return (
-    <div className={containerClass}>
+    <div className="prof-info-container">
       {/* Button to toggle popup */}
       <button
         className="prof-info-btn"
         aria-label="Professor Info"
-        onClick={handleOpen}
+        onClick={handleInfoClick}
         type="button"
       >
         {/* SVG Icon */}
@@ -234,306 +330,413 @@ export default function ProfInfoButton(props) {
       </button>
 
       {/* Popup content — only visible if `open` is true */}
-      {isOpen && (
-        <div className="prof-info-modal-overlay" onClick={handleOverlayClick}>
-          <div className="prof-info-modal" role="dialog" aria-modal="true">
-            <div className="prof-info-header">
-              <h3 className="prof-info-title">Professor Info</h3>
-              <button
-                className="prof-info-close"
-                onClick={handleOpen}
-                type="button"
-                aria-label="Close"
+      {isOpen &&
+        createPortal(
+          <Draggable
+            nodeRef={nodeRef}
+            defaultPosition={spawnPos}
+            disabled={!isDraggable} // locked by default
+            cancel="button, a .prof-info-more-btn" // prevent dragging when interacting with these elements
+            onMouseDown={bringToFront} // clicking anywhere on card brings it to the front
+          >
+            {/* Draggable requires a direct child ref with fixed positioning */}
+            <div
+              ref={nodeRef}
+              style={{ position: "fixed", zIndex: 10000, top: 0, left: 0 }}
+            >
+              <div
+                className={`prof-sticky-card ${isDraggable ? "draggable-active" : ""}`}
               >
-                X
-              </button>
-            </div>
+                {/* --- HEADER --- */}
+                <div className="prof-sticky-header">
+                  <h3 className="prof-info-title">Professor Info</h3>
 
-            {/* AMP section */}
-            <div className="campus-card">
-              <div className="campus-card-header">
-                <h4>About the Professor</h4>
-              </div>
-              <div className="campus-card-hero">
-                {isPhoto ? (
-                  <img
-                    className="prof-photo"
-                    src={isPhoto}
-                    alt="Professor photo"
-                  />
-                ) : (
-                  <img
-                    className="prof-photo"
-                    src={chrome.runtime.getURL("images/default_pfp.png")}
-                    alt="Default profile picture"
-                  />
-                )}
+                  <div className="header-controls">
+                    {/* Lock/Unlock Toggle */}
+                    <button
+                      className={`prof-pin-btn ${isDraggable ? "unlocked" : "locked"}`}
+                      onClick={toggleDraggable}
+                      type="button"
+                      title={
+                        isDraggable
+                          ? "Unlocked: Drag to move"
+                          : "Locked: Click to move"
+                      }
+                      onMouseDown={(e) => e.stopPropagation()}
+                    >
+                      {isDraggable ? (
+                        /* UNLOCKED ICON (Open Padlock) */
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="16"
+                          height="16"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        >
+                          <rect
+                            x="3"
+                            y="11"
+                            width="18"
+                            height="11"
+                            rx="2"
+                            ry="2"
+                          ></rect>
+                          <path d="M7 11V7a5 5 0 0 1 9.9-1"></path>
+                        </svg>
+                      ) : (
+                        /* LOCKED ICON (Closed Padlock) */
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="16"
+                          height="16"
+                          viewBox="0 0 24 24"
+                          fill="currentColor"
+                          stroke="none"
+                        >
+                          <rect
+                            x="3"
+                            y="11"
+                            width="18"
+                            height="11"
+                            rx="2"
+                            ry="2"
+                          ></rect>
+                          <path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
+                        </svg>
+                      )}
+                    </button>
 
-                <div className="campus-card-hero-text">
-                  <h5>{name}</h5>
-                  <div className="campus-chip-row">
-                    {department && (
-                      <span className="campus-chip">{department}</span>
-                    )}
-                    {showDivision && (
-                      <span className="campus-chip subtle">
-                        {divisionValue}
-                      </span>
-                    )}
+                    {/* Close Button */}
+                    <button
+                      className="prof-info-close"
+                      onClick={handleClose}
+                      type="button"
+                      aria-label="Close"
+                      onMouseDown={(e) => e.stopPropagation()}
+                    >
+                      X
+                    </button>
                   </div>
                 </div>
-              </div>
 
-              {/* campus card section*/}
-              {/* email/phone */}
-              {contactItems.length > 0 && (
-                <div className="campus-card-grid">
-                  {contactItems.map((item) => (
-                    <div className="campus-detail" key={item.label}>
-                      <span className="detail-label">{item.label}</span>
-                      {item.href ? (
-                        <a className="detail-value" href={item.href}>
-                          {item.value}
-                        </a>
+                {/* --- SCROLLABLE CONTENT --- */}
+                <div className="prof-sticky-content">
+                  {/* AMP section */}
+                  <div className="campus-card">
+                    <div className="campus-card-header">
+                      <h4>About the Professor</h4>
+                    </div>
+
+                    {/* Hero: Photo + Info */}
+                    <div className="campus-card-hero">
+                      {isPhoto ? (
+                        <img
+                          className="prof-photo"
+                          src={isPhoto}
+                          alt="Professor"
+                        />
                       ) : (
-                        <span className="detail-value">{item.value}</span>
+                        <img
+                          className="prof-photo"
+                          src={chrome.runtime.getURL("images/default_pfp.png")}
+                          alt="Default"
+                        />
                       )}
+
+                      <div className="campus-card-hero-text">
+                        <h5>{name}</h5>
+                        <div className="campus-chip-row">
+                          {department && (
+                            <span className="campus-chip">{department}</span>
+                          )}
+                          {showDivision && (
+                            <span className="campus-chip subtle">
+                              {divisionValue}
+                            </span>
+                          )}
+                        </div>
+                      </div>
                     </div>
-                  ))}
-                </div>
-              )}
 
-              {/* More Info Section */}
-              {hasMoreInfo && (
-                <button
-                  className="prof-info-more-btn"
-                  onClick={handleToggleMoreInfo}
-                  type="button"
-                >
-                  {showMoreInfo ? "Show Less" : "More Info"}
-                </button>
-              )}
-
-              {/* More Info Section */}
-              {showMoreInfo && (
-                <div className="prof-info-more-section">
-                  {/* office hours */}
-                  {officeHours && (
-                    <div className="campus-card-section">
-                      <p>
-                        <strong>Office Hours:</strong> {officeHours}
-                      </p>
-                    </div>
-                  )}
-
-                  {/* Courses Taught */}
-                  {Array.isArray(courses) && courses.length > 0 && (
-                    <div className="campus-card-section">
-                      <p>
-                        <strong>Courses Taught:</strong>
-                      </p>
-                      <ul>
-                        {courses.map((course, i) => (
-                          <li key={i}>{course}</li>
+                    {/* campus card section (always visible)*/}
+                    {/* email/phone */}
+                    {contactItems.length > 0 && (
+                      <div className="campus-card-grid">
+                        {contactItems.map((item) => (
+                          <div className="campus-detail" key={item.label}>
+                            <span className="detail-label">{item.label}</span>
+                            {item.href ? (
+                              <a className="detail-value" href={item.href}>
+                                {item.value}
+                              </a>
+                            ) : (
+                              <span className="detail-value">{item.value}</span>
+                            )}
+                          </div>
                         ))}
-                      </ul>
-                    </div>
-                  )}
+                      </div>
+                    )}
 
-                  {/* research interests/topics */}
-                  {researchTopicText || researchInterest ? (
-                    <div className="campus-card-section">
-                      {/* Research Interest */}
-                      {researchInterest &&
-                        typeof researchInterest === "string" && (
-                          <div
-                            dangerouslySetInnerHTML={{
-                              __html:
-                                "<p><strong>Research Interests: </strong>" +
-                                researchInterest +
-                                "</p>",
-                            }}
-                          />
+                    {/* More Info Section */}
+                    {hasMoreInfo && (
+                      <button
+                        className="prof-info-more-btn"
+                        onClick={handleToggleMoreInfo}
+                        type="button"
+                      >
+                        {showMoreInfo ? "Show Less ▲" : "More Info ▼"}
+                      </button>
+                    )}
+
+                    {showMoreInfo && (
+                      <div className="prof-info-more-section">
+                        {/* office hours */}
+                        {officeHours && (
+                          <div className="campus-card-section">
+                            <p>
+                              <strong>Office Hours:</strong> {officeHours}
+                            </p>
+                          </div>
                         )}
 
-                      {/* Research Topic */}
-                      {researchTopicText && (
-                        <div
-                          style={{
-                            marginTop: researchInterest ? "10px" : "0",
-                          }}
-                        >
-                          <p>
-                            <strong>Research Topic:</strong> {researchTopicText}
+                        {/* Courses Taught */}
+                        {Array.isArray(courses) && courses.length > 0 && (
+                          <div className="campus-card-section">
+                            <p>
+                              <strong>Courses Taught:</strong>
+                            </p>
+                            <ul>
+                              {courses.map((course, i) => (
+                                <li key={i}>{course}</li>
+                              ))}
+                            </ul>
+                          </div>
+                        )}
+
+                        {/* research interests/topics */}
+                        {researchTopicText || researchInterest ? (
+                          <div className="campus-card-section">
+                            {/* Research Interest */}
+                            {researchInterest &&
+                              typeof researchInterest === "string" && (
+                                <div
+                                  dangerouslySetInnerHTML={{
+                                    __html:
+                                      "<p><strong>Research Interests: </strong>" +
+                                      researchInterest +
+                                      "</p>",
+                                  }}
+                                />
+                              )}
+
+                            {/* Research Topic */}
+                            {researchTopicText && (
+                              <div
+                                style={{
+                                  marginTop: researchInterest ? "10px" : "0",
+                                }}
+                              >
+                                <p>
+                                  <strong>Research Topic:</strong>{" "}
+                                  {researchTopicText}
+                                </p>
+                              </div>
+                            )}
+                          </div>
+                        ) : (
+                          <div className="campus-card-section">
+                            <p>
+                              <strong>Research Info:</strong> Not listed in
+                              public directory.
+                            </p>
+                          </div>
+                        )}
+
+                        {/* Selected publications and website */}
+                        {detailItems.length > 0 && (
+                          <div className="campus-card-grid">
+                            {detailItems.map((item, index) => (
+                              <div
+                                className="campus-detail"
+                                key={`${item.label}-${index}`}
+                              >
+                                <span className="detail-label">
+                                  {item.label}
+                                </span>
+                                {item.href ? (
+                                  <a
+                                    className="detail-value"
+                                    href={item.href}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                  >
+                                    {item.value}
+                                  </a>
+                                ) : (
+                                  <span className="detail-value">
+                                    {item.value}
+                                  </span>
+                                )}
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                  {/* RMP section*/}
+                  {/* will only show if the prof does have an existing RMP profile */}
+                  {rateMyProfessor && (
+                    <div className="rmp-section">
+                      {rateMyProfessor ? (
+                        <div className="rmp-card">
+                          <div className="rmp-card-header">
+                            <h4>Rate My Professors</h4>
+                            {profileUrl && (
+                              <a
+                                href={profileUrl}
+                                target="_blank"
+                                rel="noreferrer"
+                              >
+                                View Profile
+                              </a>
+                            )}
+                          </div>
+
+                          <div className="rmp-card-grid">
+                            {/* stars rating */}
+                            <div className="rmp-metric">
+                              <span className="metric-label">Rating</span>
+                              {numRatings > 0 ? (
+                                <div className="star-rating">
+                                  <StarRating
+                                    rating={roundedRating}
+                                    numRatings={numRatings}
+                                  />
+                                </div>
+                              ) : (
+                                <span className="metric-value-na">N/A</span>
+                              )}
+                              <span className="metric-sub">
+                                {numRatings > 0
+                                  ? "Average score"
+                                  : "No ratings yet"}
+                              </span>
+                            </div>
+
+                            {/* difficulty */}
+                            <div className="rmp-metric difficulty">
+                              <span className="metric-label">Difficulty</span>
+                              <span
+                                className={`metric-value ${
+                                  roundedDifficulty &&
+                                  roundedDifficulty > 0 &&
+                                  numRatings > 0
+                                    ? roundedDifficulty >= 4
+                                      ? "diff-high"
+                                      : roundedDifficulty >= 2.6
+                                        ? "diff-mid"
+                                        : "diff-low"
+                                    : ""
+                                }`}
+                              >
+                                {roundedDifficulty &&
+                                roundedDifficulty > 0 &&
+                                numRatings > 0
+                                  ? `${formatNumber(roundedDifficulty)}/5`
+                                  : "N/A"}
+                              </span>
+                              <span className="metric-sub">Avg difficulty</span>
+                            </div>
+
+                            {/* would take again */}
+                            <div className="rmp-metric would-take">
+                              <span className="metric-label">
+                                Would Take Again
+                              </span>
+                              <span
+                                className={`metric-value ${
+                                  roundedWouldTakeAgain != null &&
+                                  roundedWouldTakeAgain >= 0 &&
+                                  numRatings > 0
+                                    ? roundedWouldTakeAgain <= 40
+                                      ? "wta-low"
+                                      : roundedWouldTakeAgain <= 70
+                                        ? "wta-mid"
+                                        : "wta-high"
+                                    : ""
+                                }`}
+                              >
+                                {roundedWouldTakeAgain != null &&
+                                roundedWouldTakeAgain >= 0 &&
+                                numRatings > 0
+                                  ? `${roundedWouldTakeAgain}%`
+                                  : "N/A"}
+                              </span>
+                              <span className="metric-sub">
+                                Student approval
+                              </span>
+                            </div>
+
+                            {/* total reviews */}
+                            <div className="rmp-metric total-ratings">
+                              <span className="metric-label">Reviews</span>
+                              <span className="metric-value">
+                                {numRatings || "0"}
+                              </span>
+                              <span className="metric-sub">Total Reviews</span>
+                            </div>
+                          </div>
+
+                          {/* top tags */}
+                          {topTags.length > 0 && (
+                            <div className="rmp-tags">
+                              <span className="tags-label">Top Tags</span>
+                              <div className="tags-grid">
+                                {topTags.slice(0, 5).map((tag) => (
+                                  <span
+                                    className="tag-chip"
+                                    key={
+                                      tag.id || tag.legacyId || Math.random()
+                                    }
+                                  >
+                                    <span className="tag-name">
+                                      {tag.tagName.length > 20
+                                        ? `${tag.tagName.substring(0, 20)}...`
+                                        : tag.tagName}
+                                    </span>
+                                    <span className="tag-count">
+                                      {tag.tagCount}
+                                    </span>
+                                  </span>
+                                ))}
+                              </div>
+                            </div>
+                          )}
+                        </div>
+                      ) : (
+                        // empty state
+                        <div className="rmp-card empty">
+                          <div className="rmp-card-header">
+                            <h4>Rate My Professors</h4>
+                          </div>
+                          <p className="rmp-empty">
+                            Rate My Professors data not available.
                           </p>
                         </div>
                       )}
                     </div>
-                  ) : (
-                    <div className="campus-card-section">
-                      <p>
-                        <strong>Research Info:</strong> Not listed in public
-                        directory.
-                      </p>
-                    </div>
-                  )}
-
-                  {/* Selected publications and website */}
-                  {detailItems.length > 0 && (
-                    <div className="campus-card-grid">
-                      {detailItems.map((item, index) => (
-                        <div
-                          className="campus-detail"
-                          key={`${item.label}-${index}`}
-                        >
-                          <span className="detail-label">{item.label}</span>
-                          {item.href ? (
-                            <a
-                              className="detail-value"
-                              href={item.href}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                            >
-                              {item.value}
-                            </a>
-                          ) : (
-                            <span className="detail-value">{item.value}</span>
-                          )}
-                        </div>
-                      ))}
-                    </div>
                   )}
                 </div>
-              )}
-            </div>
-            {/* RMP section*/}
-            {/* will only show if the prof does have an existing RMP profile */}
-            {rateMyProfessor && (
-              <div className="rmp-section">
-                {rateMyProfessor ? (
-                  <div className="rmp-card">
-                    <div className="rmp-card-header">
-                      <h4>Rate My Professors</h4>
-                      {profileUrl && (
-                        <a href={profileUrl} target="_blank" rel="noreferrer">
-                          View Profile
-                        </a>
-                      )}
-                    </div>
-
-                    <div className="rmp-card-grid">
-                      {/* stars rating */}
-                      <div className="rmp-metric rating">
-                        {numRatings > 0 ? (
-                          <StarRating
-                            rating={roundedRating}
-                            numRatings={numRatings}
-                          />
-                        ) : (
-                          <span className="metric-value-na">N/A</span>
-                        )}
-                        <span className="metric-sub">
-                          {numRatings > 0 ? "Average score" : "No ratings yet"}
-                        </span>
-                      </div>
-
-                      {/* difficulty */}
-                      <div className="rmp-metric difficulty">
-                        <span className="metric-label">Difficulty</span>
-                        <span
-                          className={`metric-value ${
-                            roundedDifficulty &&
-                            roundedDifficulty > 0 &&
-                            numRatings > 0
-                              ? roundedDifficulty >= 4
-                                ? "diff-high"
-                                : roundedDifficulty >= 2.6
-                                  ? "diff-mid"
-                                  : "diff-low"
-                              : ""
-                          }`}
-                        >
-                          {roundedDifficulty &&
-                          roundedDifficulty > 0 &&
-                          numRatings > 0
-                            ? `${formatNumber(roundedDifficulty)}/5`
-                            : "N/A"}
-                        </span>
-                        <span className="metric-sub">Avg difficulty</span>
-                      </div>
-
-                      {/* would take again */}
-                      <div className="rmp-metric would-take">
-                        <span className="metric-label">Would Take Again</span>
-                        <span
-                          className={`metric-value ${
-                            roundedWouldTakeAgain != null &&
-                            roundedWouldTakeAgain >= 0 &&
-                            numRatings > 0
-                              ? roundedWouldTakeAgain <= 40
-                                ? "wta-low"
-                                : roundedWouldTakeAgain <= 70
-                                  ? "wta-mid"
-                                  : "wta-high"
-                              : ""
-                          }`}
-                        >
-                          {roundedWouldTakeAgain != null &&
-                          roundedWouldTakeAgain >= 0 &&
-                          numRatings > 0
-                            ? `${roundedWouldTakeAgain}%`
-                            : "N/A"}
-                        </span>
-                        <span className="metric-sub">Student approval</span>
-                      </div>
-
-                      <div className="rmp-metric total-ratings">
-                        <span className="metric-label">Reviews</span>
-                        <span className="metric-value">
-                          {roundedWouldTakeAgain != null ? numRatings : "N/A"}
-                        </span>
-                        <span className="metric-sub">Total reviews</span>
-                      </div>
-                    </div>
-
-                    {/* top tags */}
-                    {topTags.length > 0 && (
-                      <div className="rmp-tags">
-                        <span className="tags-label">Top Tags</span>
-                        <div className="tags-grid">
-                          {topTags.slice(0, 5).map((tag) => (
-                            <span
-                              className="tag-chip"
-                              key={tag.id || tag.legacyId || Math.random()}
-                            >
-                              <span className="tag-name">
-                                {tag.tagName.length > 20
-                                  ? `${tag.tagName.substring(0, 20)}...`
-                                  : tag.tagName}
-                              </span>
-                              <span className="tag-count">{tag.tagCount}</span>
-                            </span>
-                          ))}
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                ) : (
-                  // empty state
-                  <div className="rmp-card empty">
-                    <div className="rmp-card-header">
-                      <h4>Rate My Professors</h4>
-                    </div>
-                    <p className="rmp-empty">
-                      Rate My Professors data not available.
-                    </p>
-                  </div>
-                )}
               </div>
-            )}
-          </div>
-        </div>
-      )}
+            </div>
+          </Draggable>,
+          document.body,
+        )}
     </div>
   );
 }

--- a/src/react/components/ProfInfoButton.jsx
+++ b/src/react/components/ProfInfoButton.jsx
@@ -1,10 +1,9 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import { createPortal } from "react-dom";
 import Draggable from "react-draggable";
 import "../styles/index.css";
 import {
   getFirst,
-  toNumber,
   roundToWhole,
   roundToOneDecimal,
   formatNumber,
@@ -35,9 +34,9 @@ export default function ProfInfoButton(props) {
   // --- DATA PROCESSING ---
   const localResearchTopic = props.localResearchTopic;
   const localClassesTaught = props.localClassesTaught;
-  const rateMyProfessor = props.rateMyProfessor;
 
   // rate my professor data - I.K
+  const rateMyProfessor = props.rateMyProfessor;
   const rating = rateMyProfessor?.avgRatingRounded;
   const numRatings = rateMyProfessor?.numRatings;
   const wouldTakeAgain = rateMyProfessor?.wouldTakeAgainPercentRounded;
@@ -55,7 +54,7 @@ export default function ProfInfoButton(props) {
   const roundedDifficulty = roundToOneDecimal(avgDifficulty);
   const roundedWouldTakeAgain = roundToWhole(wouldTakeAgain);
 
-  // Campus Directory Data
+  // --- Process Campus Directory Data ---
   const name = getFirst(props.apiData?.cn) || "Not Listed";
   const email = getFirst(props.apiData?.mail);
   const phone = getFirst(props.apiData?.telephonenumber);
@@ -85,23 +84,16 @@ export default function ProfInfoButton(props) {
 
   // --- HELPERS ---
 
-  // global id for global registry
-  const profId = name;
-
-  // --- HELPERS ---
-
   // Shorten long URLs for display
   const formatLinkLabel = (url) => {
     try {
       const u = new URL(url);
       const host = u.hostname.replace("www.", ""); // remove www.
       let path = u.pathname;
-
       // shorten long paths
       if (path.length > 20) {
         path = path.slice(0, 20) + "...";
       }
-
       return `${host}${path}`;
     } catch {
       return "Link"; // fallback
@@ -151,7 +143,6 @@ export default function ProfInfoButton(props) {
   ].filter(Boolean);
 
   // Items hidden in "More Info"
-  // Items hidden in "More Info"
   const detailItems = [
     website && {
       label: "Website",
@@ -172,6 +163,8 @@ export default function ProfInfoButton(props) {
     Boolean(researchInterest) || // Check for the keyword field
     Boolean(website) ||
     publicationLinks.length > 0;
+
+  // --- HANDLERS ---
 
   /**
    * handles photos that are valid and invalid - I.K
@@ -202,136 +195,6 @@ export default function ProfInfoButton(props) {
     e.stopPropagation();
     setIsOpen(false);
   };
-  // function to bring this specific card to the front
-  const bringToFront = useCallback(() => {
-    window.AMP_Z_INDEX += 1;
-    setZIndex(window.AMP_Z_INDEX);
-  }, []);
-
-  // logic specifically for closing
-  const handleClose = (e) => {
-    e.stopPropagation();
-    setIsOpen(false);
-  };
-
-  /**
-   * Toggles the "More Info" collapsible section.
-   */
-  function handleToggleMoreInfo(e) {
-    e.stopPropagation();
-    setShowMoreInfo((prev) => !prev);
-  }
-
-  // toggle lock/unlock for dragging
-  const toggleDraggable = (e) => {
-    e.stopPropagation();
-    setIsDraggable((prev) => !prev);
-  };
-
-  // toggle lock/unlock for dragging
-  const toggleDraggable = (e) => {
-    e.stopPropagation();
-    setIsDraggable((prev) => !prev);
-  };
-
-  /**
-   * Effect hook to load the professor's photo only when the modal is opened and we have data.  - E.H
-   * Also handles which popup appears depending on what the user clicks on
-   * Also handles which popup appears depending on what the user clicks on
-   */
-  useEffect(() => {
-    if (isOpen) {
-      handlePhotoURL();
-      window.AMP_ACTIVE_CARDS[profId] = bringToFront;
-    }
-
-    // clean up
-    return () => {
-      if (isOpen && window.AMP_ACTIVE_CARDS[profId] === bringToFront) {
-        delete window.AMP_ACTIVE_CARDS[profId];
-      }
-    };
-  }, [isOpen, handlePhotoURL, bringToFront, profId]); // runs when any of these change
-
-  // opening logic for the info button
-  const handleInfoClick = (e) => {
-    // get viewport dimensions
-    const vw = Math.max(
-      document.documentElement.clientWidth || 0,
-      window.innerWidth || 0,
-    );
-    const vh = Math.max(
-      document.documentElement.clientHeight || 0,
-      window.innerHeight || 0,
-    );
-
-    // get button position
-    const btn = e.currentTarget.getBoundingClientRect();
-
-    // define card dimensions
-    const CARD_W = 360;
-    const CARD_H = 550;
-    const GAP = 12;
-
-    // calculate X (Horizontal)
-    let finalX = btn.right + GAP; // Try placing to the right first
-
-    // Check if it goes off the right edge
-    if (finalX + CARD_W > vw) {
-      // try placing to the left
-      finalX = btn.left - CARD_W - GAP;
-    }
-
-    // check if it goes off the left edge (e.g., mobile screen)
-    if (finalX < 0) {
-      // if screen is too narrow for offsets, roughly center it
-      finalX = (vw - CARD_W) / 2;
-      // make sure it doesn't go negative even after centering attempts
-      if (finalX < 10) finalX = 10;
-    }
-
-    // calculate Y (Vertical)
-    let finalY = btn.top;
-
-    // check if it goes off the bottom edge
-    if (finalY + CARD_H > vh) {
-      // shift it up so the bottom rests near the window bottom
-      finalY = vh - CARD_H - GAP;
-    }
-
-    // check if it goes off the top edge
-    if (finalY < 10) finalY = 10;
-
-    setSpawnPos({ x: finalX, y: finalY });
-
-    // check if any card for this prof is already open
-    if (window.AMP_ACTIVE_CARDS[profId]) {
-      // if so, bring that card to front
-      window.AMP_ACTIVE_CARDS[profId]();
-      return;
-    }
-
-    // otherwise, open this specific instance
-    if (!isOpen) {
-      setIsOpen(true);
-      setShowMoreInfo(false);
-      setIsDraggable(false);
-    }
-
-    // register immediately so the very next click knows about it
-    window.AMP_ACTIVE_CARDS[profId] = bringToFront;
-    bringToFront();
-  };
-      window.AMP_ACTIVE_CARDS[profId] = bringToFront;
-    }
-
-    // clean up
-    return () => {
-      if (isOpen && window.AMP_ACTIVE_CARDS[profId] === bringToFront) {
-        delete window.AMP_ACTIVE_CARDS[profId];
-      }
-    };
-  }, [isOpen, handlePhotoURL, bringToFront, profId]); // runs when any of these change
 
   // opening logic for the info button
   const handleInfoClick = (e) => {
@@ -408,14 +271,57 @@ export default function ProfInfoButton(props) {
     return null;
   }
 
+  /**
+   * Toggles the "More Info" collapsible section.
+   */
+  function handleToggleMoreInfo(e) {
+    // Stop the click from closing the whole modal
+    // if the button is ever inside the click overlay  - E.H
+    e.stopPropagation();
+    setShowMoreInfo((prev) => !prev);
+  }
+
+  // Toggle Lock/Unlock for Dragging
+  const toggleDraggable = (e) => {
+    e.stopPropagation();
+    setIsDraggable((prev) => !prev);
+  };
+
+  /**
+   * Effect hook to load the professor's photo only when the modal is opened and we have data.  - E.H
+   */
+  useEffect(() => {
+    if (isOpen) {
+      handlePhotoURL();
+      // Register this card
+      window.AMP_ACTIVE_CARDS[profId] = bringToFront;
+    }
+    return () => {
+      if (isOpen && window.AMP_ACTIVE_CARDS[profId] === bringToFront) {
+        delete window.AMP_ACTIVE_CARDS[profId];
+      }
+    };
+  }, [isOpen, handlePhotoURL, bringToFront, profId]);
+
+  // This component won't render anything if it doesn't get apiData
+  if (!props.apiData) {
+    return null;
+  }
+
+  // When the modal is open, we add the 'prof-is-open' class to the
+  // main container. This gives it a higher z-index (1001)
+  // so it appears *above* the overlay and all other buttons.  - E.H
+  // (Note: With Portal, the containerClass mostly affects the button itself now)
+  const containerClass = isOpen
+    ? "prof-info-container prof-is-open"
+    : "prof-info-container";
+
   return (
-    <div className="prof-info-container">
-    <div className="prof-info-container">
+    <div className={containerClass}>
       {/* Button to toggle popup */}
       <button
         className="prof-info-btn"
         aria-label="Professor Info"
-        onClick={handleInfoClick}
         onClick={handleInfoClick}
         type="button"
       >
@@ -442,105 +348,13 @@ export default function ProfInfoButton(props) {
             nodeRef={nodeRef}
             defaultPosition={spawnPos}
             disabled={!isDraggable} // locked by default
-            cancel="button, a .prof-info-more-btn" // prevent dragging when interacting with these elements
+            cancel="button, a, .prof-info-more-btn" // prevent dragging when interacting with these elements
             onMouseDown={bringToFront} // clicking anywhere on card brings it to the front
           >
             {/* Draggable requires a direct child ref with fixed positioning */}
             <div
               ref={nodeRef}
-              style={{ position: "fixed", zIndex: 10000, top: 0, left: 0 }}
-            >
-              <div
-                className={`prof-sticky-card ${isDraggable ? "draggable-active" : ""}`}
-              >
-                {/* --- HEADER --- */}
-                <div className="prof-sticky-header">
-                  <h3 className="prof-info-title">Professor Info</h3>
-
-                  <div className="header-controls">
-                    {/* Lock/Unlock Toggle */}
-                    <button
-                      className={`prof-pin-btn ${isDraggable ? "unlocked" : "locked"}`}
-                      onClick={toggleDraggable}
-                      type="button"
-                      title={
-                        isDraggable
-                          ? "Unlocked: Drag to move"
-                          : "Locked: Click to move"
-                      }
-                      onMouseDown={(e) => e.stopPropagation()}
-                    >
-                      {isDraggable ? (
-                        /* UNLOCKED ICON (Open Padlock) */
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          width="16"
-                          height="16"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2"
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                        >
-                          <rect
-                            x="3"
-                            y="11"
-                            width="18"
-                            height="11"
-                            rx="2"
-                            ry="2"
-                          ></rect>
-                          <path d="M7 11V7a5 5 0 0 1 9.9-1"></path>
-                        </svg>
-                      ) : (
-                        /* LOCKED ICON (Closed Padlock) */
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          width="16"
-                          height="16"
-                          viewBox="0 0 24 24"
-                          fill="currentColor"
-                          stroke="none"
-                        >
-                          <rect
-                            x="3"
-                            y="11"
-                            width="18"
-                            height="11"
-                            rx="2"
-                            ry="2"
-                          ></rect>
-                          <path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
-                        </svg>
-                      )}
-                    </button>
-
-                    {/* Close Button */}
-                    <button
-                      className="prof-info-close"
-                      onClick={handleClose}
-                      type="button"
-                      aria-label="Close"
-                      onMouseDown={(e) => e.stopPropagation()}
-                    >
-                      X
-                    </button>
-                  </div>
-                </div>
-      {isOpen &&
-        createPortal(
-          <Draggable
-            nodeRef={nodeRef}
-            defaultPosition={spawnPos}
-            disabled={!isDraggable} // locked by default
-            cancel="button, a .prof-info-more-btn" // prevent dragging when interacting with these elements
-            onMouseDown={bringToFront} // clicking anywhere on card brings it to the front
-          >
-            {/* Draggable requires a direct child ref with fixed positioning */}
-            <div
-              ref={nodeRef}
-              style={{ position: "fixed", zIndex: 10000, top: 0, left: 0 }}
+              style={{ position: "fixed", zIndex: zIndex, top: 0, left: 0 }}
             >
               <div
                 className={`prof-sticky-card ${isDraggable ? "draggable-active" : ""}`}
@@ -621,7 +435,7 @@ export default function ProfInfoButton(props) {
                   </div>
                 </div>
 
-                {/* --- SCROLLABLE CONTENT --- */}
+                {/* --- CONTENT --- */}
                 <div className="prof-sticky-content">
                   {/* AMP section */}
                   <div className="campus-card">
@@ -629,19 +443,18 @@ export default function ProfInfoButton(props) {
                       <h4>About the Professor</h4>
                     </div>
 
-                    {/* Hero: Photo + Info */}
                     <div className="campus-card-hero">
                       {isPhoto ? (
                         <img
                           className="prof-photo"
                           src={isPhoto}
-                          alt="Professor"
+                          alt="Professor photo"
                         />
                       ) : (
                         <img
                           className="prof-photo"
                           src={chrome.runtime.getURL("images/default_pfp.png")}
-                          alt="Default"
+                          alt="Default profile picture"
                         />
                       )}
 
@@ -678,26 +491,8 @@ export default function ProfInfoButton(props) {
                         ))}
                       </div>
                     )}
-                    {/* campus card section (always visible)*/}
-                    {/* email/phone */}
-                    {contactItems.length > 0 && (
-                      <div className="campus-card-grid">
-                        {contactItems.map((item) => (
-                          <div className="campus-detail" key={item.label}>
-                            <span className="detail-label">{item.label}</span>
-                            {item.href ? (
-                              <a className="detail-value" href={item.href}>
-                                {item.value}
-                              </a>
-                            ) : (
-                              <span className="detail-value">{item.value}</span>
-                            )}
-                          </div>
-                        ))}
-                      </div>
-                    )}
 
-                    {/* More Info Section */}
+                    {/* More Info button */}
                     {hasMoreInfo && (
                       <button
                         className="prof-info-more-btn"
@@ -708,19 +503,9 @@ export default function ProfInfoButton(props) {
                       </button>
                     )}
 
+                    {/* More Info Section */}
                     {showMoreInfo && (
                       <div className="prof-info-more-section">
-                        {/* office hours */}
-                        {officeHours && (
-                          <div className="campus-card-section">
-                            <p>
-                              <strong>Office Hours:</strong> {officeHours}
-                            </p>
-                          </div>
-                        )}
-                    {showMoreInfo && (
-                      <div className="prof-info-more-section">
-                        {/* office hours */}
                         {officeHours && (
                           <div className="campus-card-section">
                             <p>
@@ -740,45 +525,6 @@ export default function ProfInfoButton(props) {
                                 <li key={i}>{course}</li>
                               ))}
                             </ul>
-                          </div>
-                        )}
-
-                        {/* research interests/topics */}
-                        {researchTopicText || researchInterest ? (
-                          <div className="campus-card-section">
-                            {/* Research Interest */}
-                            {researchInterest &&
-                              typeof researchInterest === "string" && (
-                                <div
-                                  dangerouslySetInnerHTML={{
-                                    __html:
-                                      "<p><strong>Research Interests: </strong>" +
-                                      researchInterest +
-                                      "</p>",
-                                  }}
-                                />
-                              )}
-
-                            {/* Research Topic */}
-                            {researchTopicText && (
-                              <div
-                                style={{
-                                  marginTop: researchInterest ? "10px" : "0",
-                                }}
-                              >
-                                <p>
-                                  <strong>Research Topic:</strong>{" "}
-                                  {researchTopicText}
-                                </p>
-                              </div>
-                            )}
-                          </div>
-                        ) : (
-                          <div className="campus-card-section">
-                            <p>
-                              <strong>Research Info:</strong> Not listed in
-                              public directory.
-                            </p>
                           </div>
                         )}
 
@@ -811,9 +557,47 @@ export default function ProfInfoButton(props) {
                             ))}
                           </div>
                         )}
+
+                        {/* research interests/topics */}
+                        {researchTopicText || researchInterest ? (
+                          <div className="campus-card-section">
+                            {researchInterest &&
+                              typeof researchInterest === "string" && (
+                                <div
+                                  dangerouslySetInnerHTML={{
+                                    __html:
+                                      "<p><strong>Research Interests: </strong>" +
+                                      researchInterest +
+                                      "</p>",
+                                  }}
+                                />
+                              )}
+
+                            {researchTopicText && (
+                              <div
+                                style={{
+                                  marginTop: researchInterest ? "10px" : "0",
+                                }}
+                              >
+                                <p>
+                                  <strong>Research Topic:</strong>{" "}
+                                  {researchTopicText}
+                                </p>
+                              </div>
+                            )}
+                          </div>
+                        ) : (
+                          <div className="campus-card-section">
+                            <p>
+                              <strong>Research Info:</strong> Not listed in
+                              public directory.
+                            </p>
+                          </div>
+                        )}
                       </div>
                     )}
                   </div>
+
                   {/* RMP section*/}
                   {/* will only show if the prof does have an existing RMP profile */}
                   {rateMyProfessor && (
@@ -834,11 +618,11 @@ export default function ProfInfoButton(props) {
                           </div>
 
                           <div className="rmp-card-grid">
-                            {/* stars rating */}
                             <div className="rmp-metric">
                               <span className="metric-label">Rating</span>
                               {numRatings > 0 ? (
                                 <div className="star-rating">
+                                  {/* stars rating */}
                                   <StarRating
                                     rating={roundedRating}
                                     numRatings={numRatings}
@@ -848,55 +632,19 @@ export default function ProfInfoButton(props) {
                                 <span className="metric-value-na">N/A</span>
                               )}
                               <span className="metric-sub">
-                                {numRatings > 0
-                                  ? "Average score"
-                                  : "No ratings yet"}
-                              </span>
-                            </div>
-                          <div className="rmp-card-grid">
-                            {/* stars rating */}
-                            <div className="rmp-metric">
-                              <span className="metric-label">Rating</span>
-                              {numRatings > 0 ? (
-                                <div className="star-rating">
-                                  <StarRating
-                                    rating={roundedRating}
-                                    numRatings={numRatings}
-                                  />
-                                </div>
-                              ) : (
-                                <span className="metric-value-na">N/A</span>
-                              )}
-                              <span className="metric-sub">
-                                {numRatings > 0
-                                  ? "Average score"
-                                  : "No ratings yet"}
+                                {roundedRating || "N/A"} / 5
                               </span>
                             </div>
 
                             {/* difficulty */}
                             <div className="rmp-metric difficulty">
                               <span className="metric-label">Difficulty</span>
-                              <span
-                                className={`metric-value ${
-                                  roundedDifficulty &&
-                                  roundedDifficulty > 0 &&
-                                  numRatings > 0
-                                    ? roundedDifficulty >= 4
-                                      ? "diff-high"
-                                      : roundedDifficulty >= 2.6
-                                        ? "diff-mid"
-                                        : "diff-low"
-                                    : ""
-                                }`}
-                              >
-                                {roundedDifficulty &&
-                                roundedDifficulty > 0 &&
-                                numRatings > 0
-                                  ? `${formatNumber(roundedDifficulty)}/5`
+                              <span className="metric-value">
+                                {roundedDifficulty && numRatings > 0
+                                  ? roundedDifficulty
                                   : "N/A"}
                               </span>
-                              <span className="metric-sub">Avg difficulty</span>
+                              <span className="metric-sub">Avg Difficulty</span>
                             </div>
 
                             {/* would take again */}
@@ -904,39 +652,16 @@ export default function ProfInfoButton(props) {
                               <span className="metric-label">
                                 Would Take Again
                               </span>
-                              <span
-                                className={`metric-value ${
-                                  roundedWouldTakeAgain != null &&
-                                  roundedWouldTakeAgain >= 0 &&
-                                  numRatings > 0
-                                    ? roundedWouldTakeAgain <= 40
-                                      ? "wta-low"
-                                      : roundedWouldTakeAgain <= 70
-                                        ? "wta-mid"
-                                        : "wta-high"
-                                    : ""
-                                }`}
-                              >
-                                {roundedWouldTakeAgain != null &&
-                                roundedWouldTakeAgain >= 0 &&
-                                numRatings > 0
+                              <span className="metric-value">
+                                {roundedWouldTakeAgain != null && numRatings > 0
                                   ? `${roundedWouldTakeAgain}%`
                                   : "N/A"}
                               </span>
                               <span className="metric-sub">
-                                Student approval
+                                Student Approval
                               </span>
                             </div>
 
-                            {/* total reviews */}
-                            <div className="rmp-metric total-ratings">
-                              <span className="metric-label">Reviews</span>
-                              <span className="metric-value">
-                                {numRatings || "0"}
-                              </span>
-                              <span className="metric-sub">Total Reviews</span>
-                            </div>
-                          </div>
                             {/* total reviews */}
                             <div className="rmp-metric total-ratings">
                               <span className="metric-label">Reviews</span>
@@ -955,13 +680,11 @@ export default function ProfInfoButton(props) {
                                 {topTags.slice(0, 5).map((tag) => (
                                   <span
                                     className="tag-chip"
-                                    key={
-                                      tag.id || tag.legacyId || Math.random()
-                                    }
+                                    key={tag.id || Math.random()}
                                   >
                                     <span className="tag-name">
                                       {tag.tagName.length > 20
-                                        ? `${tag.tagName.substring(0, 20)}...`
+                                        ? tag.tagName.substring(0, 20) + "..."
                                         : tag.tagName}
                                     </span>
                                     <span className="tag-count">

--- a/src/react/components/ProfInfoButton.jsx
+++ b/src/react/components/ProfInfoButton.jsx
@@ -1,4 +1,6 @@
-import React, { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
+import { createPortal } from "react-dom";
+import Draggable from "react-draggable";
 import "../styles/index.css";
 import {
   getFirst,
@@ -9,15 +11,32 @@ import {
   StarRating,
 } from "../../utils/utils";
 
+// track the highest Z-Index across all professor buttons
+// ensures that the most recently clicked card always pops to the front  - E.H
+if (typeof window.AMP_Z_INDEX === "undefined") {
+  window.AMP_Z_INDEX = 10000;
+}
+
+// active card registry: prevents duplicates
+if (typeof window.AMP_ACTIVE_CARDS === "undefined") {
+  window.AMP_ACTIVE_CARDS = {};
+}
+
 export default function ProfInfoButton(props) {
-  // Track whether popup is open or closed
-  const [isOpen, setIsOpen] = useState(false);
-  const [isPhoto, setIsPhoto] = useState("");
-  const [showMoreInfo, setShowMoreInfo] = useState(false);
+  // --- STATES ---
+  const [isOpen, setIsOpen] = useState(false); // for the open/close functionality of info button
+  const [isPhoto, setIsPhoto] = useState(""); // for the professor profile pic
+  const [showMoreInfo, setShowMoreInfo] = useState(false); // for more info button
+  const [isDraggable, setIsDraggable] = useState(false); // dragging state (default = locked)
+  const [zIndex, setZIndex] = useState(window.AMP_Z_INDEX); // local z-index state for popup placement
+  const [spawnPos, setSpawnPos] = useState({ x: 0, y: 0 }); // local state to store where the modal should appear
+  const nodeRef = useRef(null); // Ref required for draggable in React StrictMode
+
+  // --- DATA PROCESSING ---
   const localResearchTopic = props.localResearchTopic;
+  const rateMyProfessor = props.rateMyProfessor;
 
   // rate my professor data - I.K
-  const rateMyProfessor = props.rateMyProfessor;
   const rating = rateMyProfessor?.avgRatingRounded;
   const numRatings = rateMyProfessor?.numRatings;
   const wouldTakeAgain = rateMyProfessor?.wouldTakeAgainPercentRounded;
@@ -35,7 +54,7 @@ export default function ProfInfoButton(props) {
   const roundedDifficulty = roundToOneDecimal(avgDifficulty);
   const roundedWouldTakeAgain = roundToWhole(wouldTakeAgain);
 
-  // --- Process Campus Directory Data ---
+  // Campus Directory Data
   const name = getFirst(props.apiData?.cn) || "Not Listed";
   const email = getFirst(props.apiData?.mail);
   const phone = getFirst(props.apiData?.telephonenumber);
@@ -46,7 +65,7 @@ export default function ProfInfoButton(props) {
   const researchInterest = getFirst(
     props.apiData?.ucscpersonpubresearchinterest,
   );
-  const courses = props.apiData?.ucscpersonpubfacultycourses; // assumes this is already an array
+  const courses = props.apiData?.ucscpersonpubfacultycourses;
 
   const normalize = (value) =>
     String(value || "")
@@ -59,16 +78,23 @@ export default function ProfInfoButton(props) {
     department &&
     normalize(divisionValue) !== normalize(department);
 
+  // global id for global registry
+  const profId = name;
+
+  // --- HELPERS ---
+
   // Shorten long URLs for display
   const formatLinkLabel = (url) => {
     try {
       const u = new URL(url);
       const host = u.hostname.replace("www.", ""); // remove www.
       let path = u.pathname;
+
       // shorten long paths
       if (path.length > 20) {
         path = path.slice(0, 20) + "...";
       }
+
       return `${host}${path}`;
     } catch {
       return "Link"; // fallback
@@ -117,6 +143,7 @@ export default function ProfInfoButton(props) {
     phone && { label: "Phone", value: phone, href: `tel:${phone}` },
   ].filter(Boolean);
 
+  // Items hidden in "More Info"
   const detailItems = [
     website && {
       label: "Website",
@@ -156,62 +183,132 @@ export default function ProfInfoButton(props) {
     }
   }, [props.apiData]); // This function now only changes if apiData changes
 
-  /**
-   * Handles opening and closing of pop up - I.K
-   * Also resets the "Show More" toggle when closing.  - E.H
-   */
-  function handleOpen() {
-    setIsOpen((prev) => !prev);
-    if (isOpen) {
-      setShowMoreInfo(false);
-    }
-  }
+  // function to bring this specific card to the front
+  const bringToFront = useCallback(() => {
+    window.AMP_Z_INDEX += 1;
+    setZIndex(window.AMP_Z_INDEX);
+  }, []);
+
+  // logic specifically for closing
+  const handleClose = (e) => {
+    e.stopPropagation();
+    setIsOpen(false);
+  };
 
   /**
    * Toggles the "More Info" collapsible section.
    */
   function handleToggleMoreInfo(e) {
-    // Stop the click from closing the whole modal
-    // if the button is ever inside the click overlay  - E.H
     e.stopPropagation();
     setShowMoreInfo((prev) => !prev);
   }
 
+  // toggle lock/unlock for dragging
+  const toggleDraggable = (e) => {
+    e.stopPropagation();
+    setIsDraggable((prev) => !prev);
+  };
+
   /**
    * Effect hook to load the professor's photo only when the modal is opened and we have data.  - E.H
+   * Also handles which popup appears depending on what the user clicks on
    */
   useEffect(() => {
     if (isOpen) {
       handlePhotoURL();
+      window.AMP_ACTIVE_CARDS[profId] = bringToFront;
     }
-  }, [isOpen, handlePhotoURL]); // Runs when 'isOpen' or 'handlePhotoURL' changes
 
-  function handleOverlayClick(event) {
-    if (event.target === event.currentTarget) {
-      setIsOpen(false);
-      setShowMoreInfo(false); // also reset on overlay click
+    // clean up
+    return () => {
+      if (isOpen && window.AMP_ACTIVE_CARDS[profId] === bringToFront) {
+        delete window.AMP_ACTIVE_CARDS[profId];
+      }
+    };
+  }, [isOpen, handlePhotoURL, bringToFront, profId]); // runs when any of these change
+
+  // opening logic for the info button
+  const handleInfoClick = (e) => {
+    // get viewport dimensions
+    const vw = Math.max(
+      document.documentElement.clientWidth || 0,
+      window.innerWidth || 0,
+    );
+    const vh = Math.max(
+      document.documentElement.clientHeight || 0,
+      window.innerHeight || 0,
+    );
+
+    // get button position
+    const btn = e.currentTarget.getBoundingClientRect();
+
+    // define card dimensions
+    const CARD_W = 360;
+    const CARD_H = 550;
+    const GAP = 12;
+
+    // calculate X (Horizontal)
+    let finalX = btn.right + GAP; // Try placing to the right first
+
+    // Check if it goes off the right edge
+    if (finalX + CARD_W > vw) {
+      // try placing to the left
+      finalX = btn.left - CARD_W - GAP;
     }
-  }
+
+    // check if it goes off the left edge (e.g., mobile screen)
+    if (finalX < 0) {
+      // if screen is too narrow for offsets, roughly center it
+      finalX = (vw - CARD_W) / 2;
+      // make sure it doesn't go negative even after centering attempts
+      if (finalX < 10) finalX = 10;
+    }
+
+    // calculate Y (Vertical)
+    let finalY = btn.top;
+
+    // check if it goes off the bottom edge
+    if (finalY + CARD_H > vh) {
+      // shift it up so the bottom rests near the window bottom
+      finalY = vh - CARD_H - GAP;
+    }
+
+    // check if it goes off the top edge
+    if (finalY < 10) finalY = 10;
+
+    setSpawnPos({ x: finalX, y: finalY });
+
+    // check if any card for this prof is already open
+    if (window.AMP_ACTIVE_CARDS[profId]) {
+      // if so, bring that card to front
+      window.AMP_ACTIVE_CARDS[profId]();
+      return;
+    }
+
+    // otherwise, open this specific instance
+    if (!isOpen) {
+      setIsOpen(true);
+      setShowMoreInfo(false);
+      setIsDraggable(false);
+    }
+
+    // register immediately so the very next click knows about it
+    window.AMP_ACTIVE_CARDS[profId] = bringToFront;
+    bringToFront();
+  };
 
   // This component won't render anything if it doesn't get apiData
   if (!props.apiData) {
     return null;
   }
 
-  // When the modal is open, we add the 'prof-is-open' class to the
-  // main container. This gives it a higher z-index (1001)
-  // so it appears *above* the overlay and all other buttons.  - E.H
-  const containerClass = isOpen
-    ? "prof-info-container prof-is-open"
-    : "prof-info-container";
-
   return (
-    <div className={containerClass}>
+    <div className="prof-info-container">
       {/* Button to toggle popup */}
       <button
         className="prof-info-btn"
         aria-label="Professor Info"
-        onClick={handleOpen}
+        onClick={handleInfoClick}
         type="button"
       >
         {/* SVG Icon */}
@@ -231,283 +328,384 @@ export default function ProfInfoButton(props) {
       </button>
 
       {/* Popup content — only visible if `open` is true */}
-      {isOpen && (
-        <div className="prof-info-modal-overlay" onClick={handleOverlayClick}>
-          <div className="prof-info-modal" role="dialog" aria-modal="true">
-            <div className="prof-info-header">
-              <h3 className="prof-info-title">Professor Info</h3>
-              <button
-                className="prof-info-close"
-                onClick={handleOpen}
-                type="button"
-                aria-label="Close"
+      {isOpen &&
+        createPortal(
+          <Draggable
+            nodeRef={nodeRef}
+            defaultPosition={spawnPos}
+            disabled={!isDraggable} // locked by default
+            cancel="button, a .prof-info-more-btn" // prevent dragging when interacting with these elements
+            onMouseDown={bringToFront} // clicking anywhere on card brings it to the front
+          >
+            {/* Draggable requires a direct child ref with fixed positioning */}
+            <div
+              ref={nodeRef}
+              style={{ position: "fixed", zIndex: 10000, top: 0, left: 0 }}
+            >
+              <div
+                className={`prof-sticky-card ${isDraggable ? "draggable-active" : ""}`}
               >
-                X
-              </button>
-            </div>
+                {/* --- HEADER --- */}
+                <div className="prof-sticky-header">
+                  <h3 className="prof-info-title">Professor Info</h3>
 
-            {/* AMP section */}
-            <div className="campus-card">
-              <div className="campus-card-header">
-                <h4>About the Professor</h4>
-              </div>
-              <div className="campus-card-hero">
-                {isPhoto ? (
-                  <img
-                    className="prof-photo"
-                    src={isPhoto}
-                    alt="Professor photo"
-                  />
-                ) : (
-                  <img
-                    className="prof-photo"
-                    src={chrome.runtime.getURL("images/default_pfp.png")}
-                    alt="Default profile picture"
-                  />
-                )}
+                  <div className="header-controls">
+                    {/* Lock/Unlock Toggle */}
+                    <button
+                      className={`prof-pin-btn ${isDraggable ? "unlocked" : "locked"}`}
+                      onClick={toggleDraggable}
+                      type="button"
+                      title={
+                        isDraggable
+                          ? "Unlocked: Drag to move"
+                          : "Locked: Click to move"
+                      }
+                      onMouseDown={(e) => e.stopPropagation()}
+                    >
+                      {isDraggable ? (
+                        /* UNLOCKED ICON (Open Padlock) */
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="16"
+                          height="16"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        >
+                          <rect
+                            x="3"
+                            y="11"
+                            width="18"
+                            height="11"
+                            rx="2"
+                            ry="2"
+                          ></rect>
+                          <path d="M7 11V7a5 5 0 0 1 9.9-1"></path>
+                        </svg>
+                      ) : (
+                        /* LOCKED ICON (Closed Padlock) */
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="16"
+                          height="16"
+                          viewBox="0 0 24 24"
+                          fill="currentColor"
+                          stroke="none"
+                        >
+                          <rect
+                            x="3"
+                            y="11"
+                            width="18"
+                            height="11"
+                            rx="2"
+                            ry="2"
+                          ></rect>
+                          <path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
+                        </svg>
+                      )}
+                    </button>
 
-                <div className="campus-card-hero-text">
-                  <h5>{name}</h5>
-                  <div className="campus-chip-row">
-                    {department && (
-                      <span className="campus-chip">{department}</span>
-                    )}
-                    {showDivision && (
-                      <span className="campus-chip subtle">
-                        {divisionValue}
-                      </span>
-                    )}
+                    {/* Close Button */}
+                    <button
+                      className="prof-info-close"
+                      onClick={handleClose}
+                      type="button"
+                      aria-label="Close"
+                      onMouseDown={(e) => e.stopPropagation()}
+                    >
+                      X
+                    </button>
                   </div>
                 </div>
-              </div>
 
-              {/* campus card section*/}
-              {/* email/phone */}
-              {contactItems.length > 0 && (
-                <div className="campus-card-grid">
-                  {contactItems.map((item) => (
-                    <div className="campus-detail" key={item.label}>
-                      <span className="detail-label">{item.label}</span>
-                      {item.href ? (
-                        <a className="detail-value" href={item.href}>
-                          {item.value}
-                        </a>
+                {/* --- SCROLLABLE CONTENT --- */}
+                <div className="prof-sticky-content">
+                  {/* AMP section */}
+                  <div className="campus-card">
+                    <div className="campus-card-header">
+                      <h4>About the Professor</h4>
+                    </div>
+
+                    {/* Hero: Photo + Info */}
+                    <div className="campus-card-hero">
+                      {isPhoto ? (
+                        <img
+                          className="prof-photo"
+                          src={isPhoto}
+                          alt="Professor"
+                        />
                       ) : (
-                        <span className="detail-value">{item.value}</span>
+                        <img
+                          className="prof-photo"
+                          src={chrome.runtime.getURL("images/default_pfp.png")}
+                          alt="Default"
+                        />
                       )}
-                    </div>
-                  ))}
-                </div>
-              )}
 
-              {/* More Info Section */}
-              {hasMoreInfo && (
-                <button
-                  className="prof-info-more-btn"
-                  onClick={handleToggleMoreInfo}
-                  type="button"
-                >
-                  {showMoreInfo ? "Show Less" : "More Info"}
-                </button>
-              )}
-
-              {/* More Info Section */}
-              {showMoreInfo && (
-                <div className="prof-info-more-section">
-                  {/* office hours */}
-                  {officeHours && (
-                    <div className="campus-card-section">
-                      <p>
-                        <strong>Office Hours:</strong> {officeHours}
-                      </p>
-                    </div>
-                  )}
-
-                  {/* Courses Taught */}
-                  {Array.isArray(courses) && courses.length > 0 && (
-                    <div className="campus-card-section">
-                      <p>
-                        <strong>Courses Taught:</strong>
-                      </p>
-                      <ul>
-                        {courses.map((course, i) => (
-                          <li key={i}>{course}</li>
-                        ))}
-                      </ul>
-                    </div>
-                  )}
-
-                  {/* Selected publications and website */}
-                  {detailItems.length > 0 && (
-                    <div className="campus-card-grid">
-                      {detailItems.map((item, index) => (
-                        <div
-                          className="campus-detail"
-                          key={`${item.label}-${index}`}
-                        >
-                          <span className="detail-label">{item.label}</span>
-                          {item.href ? (
-                            <a
-                              className="detail-value"
-                              href={item.href}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                            >
-                              {item.value}
-                            </a>
-                          ) : (
-                            <span className="detail-value">{item.value}</span>
+                      <div className="campus-card-hero-text">
+                        <h5>{name}</h5>
+                        <div className="campus-chip-row">
+                          {department && (
+                            <span className="campus-chip">{department}</span>
+                          )}
+                          {showDivision && (
+                            <span className="campus-chip subtle">
+                              {divisionValue}
+                            </span>
                           )}
                         </div>
-                      ))}
+                      </div>
                     </div>
-                  )}
 
-                  {/* research interests/topics */}
-                  {researchTopicText || researchInterest ? (
-                    <div className="campus-card-section">
-                      {/* Research Interest */}
-                      {researchInterest &&
-                        typeof researchInterest === "string" && (
-                          <div
-                            dangerouslySetInnerHTML={{
-                              __html:
-                                "<p><strong>Research Interests: </strong>" +
-                                researchInterest +
-                                "</p>",
-                            }}
-                          />
+                    {/* campus card section (always visible)*/}
+                    {/* email/phone */}
+                    {contactItems.length > 0 && (
+                      <div className="campus-card-grid">
+                        {contactItems.map((item) => (
+                          <div className="campus-detail" key={item.label}>
+                            <span className="detail-label">{item.label}</span>
+                            {item.href ? (
+                              <a className="detail-value" href={item.href}>
+                                {item.value}
+                              </a>
+                            ) : (
+                              <span className="detail-value">{item.value}</span>
+                            )}
+                          </div>
+                        ))}
+                      </div>
+                    )}
+
+                    {/* More Info Section */}
+                    {hasMoreInfo && (
+                      <button
+                        className="prof-info-more-btn"
+                        onClick={handleToggleMoreInfo}
+                        type="button"
+                      >
+                        {showMoreInfo ? "Show Less ▼" : "More Info ▶"}
+                      </button>
+                    )}
+
+                    {showMoreInfo && (
+                      <div className="prof-info-more-section">
+                        {/* office hours */}
+                        {officeHours && (
+                          <div className="campus-card-section">
+                            <p>
+                              <strong>Office Hours:</strong> {officeHours}
+                            </p>
+                          </div>
                         )}
 
-                      {/* Research Topic */}
-                      {researchTopicText && (
-                        <div
-                          style={{
-                            marginTop: researchInterest ? "10px" : "0",
-                          }}
-                        >
-                          <p>
-                            <strong>Research Topic:</strong> {researchTopicText}
+                        {/* Courses Taught */}
+                        {Array.isArray(courses) && courses.length > 0 && (
+                          <div className="campus-card-section">
+                            <p>
+                              <strong>Courses Taught:</strong>
+                            </p>
+                            <ul>
+                              {courses.map((course, i) => (
+                                <li key={i}>{course}</li>
+                              ))}
+                            </ul>
+                          </div>
+                        )}
+
+                        {/* Selected publications and website */}
+                        {detailItems.length > 0 && (
+                          <div className="campus-card-grid">
+                            {detailItems.map((item, index) => (
+                              <div
+                                className="campus-detail"
+                                key={`${item.label}-${index}`}
+                              >
+                                <span className="detail-label">
+                                  {item.label}
+                                </span>
+                                {item.href ? (
+                                  <a
+                                    className="detail-value"
+                                    href={item.href}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                  >
+                                    {item.value}
+                                  </a>
+                                ) : (
+                                  <span className="detail-value">
+                                    {item.value}
+                                  </span>
+                                )}
+                              </div>
+                            ))}
+                          </div>
+                        )}
+
+                        {/* research interests/topics */}
+                        {researchTopicText || researchInterest ? (
+                          <div className="campus-card-section">
+                            {researchInterest &&
+                              typeof researchInterest === "string" && (
+                                <div
+                                  dangerouslySetInnerHTML={{
+                                    __html:
+                                      "<p><strong>Research Interests: </strong>" +
+                                      researchInterest +
+                                      "</p>",
+                                  }}
+                                />
+                              )}
+                            {/* Research Topic */}
+                            {researchTopicText && (
+                              <div
+                                style={{
+                                  marginTop: researchInterest ? "10px" : "0",
+                                }}
+                              >
+                                <p>
+                                  <strong>Research Topic:</strong>{" "}
+                                  {researchTopicText}
+                                </p>
+                              </div>
+                            )}
+                          </div>
+                        ) : (
+                          <div className="campus-card-section">
+                            <p>
+                              <strong>Research Info:</strong> Not listed in
+                              public directory.
+                            </p>
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </div>
+
+                  {/* RMP section*/}
+                  {/* will only show if the prof does have a existing rmp profile */}
+                  {rateMyProfessor && (
+                    <div className="rmp-section">
+                      {rateMyProfessor ? (
+                        <div className="rmp-card">
+                          <div className="rmp-card-header">
+                            <h4>Rate My Professors</h4>
+                            {profileUrl && (
+                              <a
+                                href={profileUrl}
+                                target="_blank"
+                                rel="noreferrer"
+                              >
+                                View Profile
+                              </a>
+                            )}
+                          </div>
+
+                          <div className="rmp-card-grid">
+                            {/* stars rating */}
+                            <div className="rmp-metric">
+                              <span className="metric-label">Rating</span>
+                              {numRatings > 0 ? (
+                                <div className="star-rating">
+                                  <StarRating
+                                    rating={roundedRating}
+                                    numRatings={numRatings}
+                                  />
+                                </div>
+                              ) : (
+                                <span className="metric-value-na">N/A</span>
+                              )}
+                              <span className="metric-sub">
+                                {numRatings > 0
+                                  ? "Average score"
+                                  : "No ratings yet"}
+                              </span>
+                            </div>
+
+                            {/* difficulty */}
+                            <div className="rmp-metric difficulty">
+                              <span className="metric-label">Difficulty</span>
+                              <span className="metric-value">
+                                {roundedDifficulty && numRatings > 0
+                                  ? roundedDifficulty
+                                  : "N/A"}
+                              </span>
+                              <span className="metric-sub">Avg Difficulty</span>
+                            </div>
+
+                            {/* would take again */}
+                            <div className="rmp-metric would-take">
+                              <span className="metric-label">
+                                Would Take Again
+                              </span>
+                              <span className="metric-value">
+                                {roundedWouldTakeAgain != null && numRatings > 0
+                                  ? `${roundedWouldTakeAgain}%`
+                                  : "N/A"}
+                              </span>
+                              <span className="metric-sub">
+                                Student Approval
+                              </span>
+                            </div>
+
+                            {/* total reviews */}
+                            <div className="rmp-metric total-ratings">
+                              <span className="metric-label">Reviews</span>
+                              <span className="metric-value">
+                                {numRatings || "0"}
+                              </span>
+                              <span className="metric-sub">Total Reviews</span>
+                            </div>
+                          </div>
+
+                          {/* top tags */}
+                          {topTags.length > 0 && (
+                            <div className="rmp-tags">
+                              <span className="tags-label">Top Tags</span>
+                              <div className="tags-grid">
+                                {topTags.slice(0, 5).map((tag) => (
+                                  <span
+                                    className="tag-chip"
+                                    key={
+                                      tag.id || tag.legacyId || Math.random()
+                                    }
+                                  >
+                                    <span className="tag-name">
+                                      {tag.tagName.length > 20
+                                        ? tag.tagName.substring(0, 20) + "..."
+                                        : tag.tagName}
+                                    </span>
+                                    <span className="tag-count">
+                                      {tag.tagCount}
+                                    </span>
+                                  </span>
+                                ))}
+                              </div>
+                            </div>
+                          )}
+                        </div>
+                      ) : (
+                        // empty state
+                        <div className="rmp-card empty">
+                          <div className="rmp-card-header">
+                            <h4>Rate My Professors</h4>
+                          </div>
+                          <p className="rmp-empty">
+                            Rate My Professors data not available.
                           </p>
                         </div>
                       )}
                     </div>
-                  ) : (
-                    <div className="campus-card-section">
-                      <p>
-                        <strong>Research Info:</strong> Not listed in public
-                        directory.
-                      </p>
-                    </div>
                   )}
                 </div>
-              )}
-            </div>
-
-            {/* RMP section*/}
-            {/* will only show if the prof does have a existing rmp profile */}
-            {rateMyProfessor && (
-              <div className="rmp-section">
-                {rateMyProfessor ? (
-                  <div className="rmp-card">
-                    <div className="rmp-card-header">
-                      <h4>Rate My Professors</h4>
-                      {profileUrl && (
-                        <a href={profileUrl} target="_blank" rel="noreferrer">
-                          View Profile
-                        </a>
-                      )}
-                    </div>
-
-                    <div className="rmp-card-grid">
-                      {/* stars rating */}
-                      <div className="rmp-metric rating">
-                        {numRatings > 0 ? (
-                          <StarRating
-                            rating={roundedRating}
-                            numRatings={numRatings}
-                          />
-                        ) : (
-                          <span className="metric-value-na">N/A</span>
-                        )}
-                        <span className="metric-sub">
-                          {numRatings > 0 ? "Average score" : "No ratings yet"}
-                        </span>
-                      </div>
-
-                      {/* difficulty */}
-                      <div className="rmp-metric difficulty">
-                        <span className="metric-label">Difficulty</span>
-                        <span className="metric-value">
-                          {roundedDifficulty &&
-                          roundedDifficulty > 0 &&
-                          numRatings > 0
-                            ? `${formatNumber(roundedDifficulty)}/5`
-                            : "N/A"}
-                        </span>
-                        <span className="metric-sub">Avg difficulty</span>
-                      </div>
-
-                      {/* would take */}
-                      <div className="rmp-metric would-take">
-                        <span className="metric-label">Would Take Again</span>
-                        <span className="metric-value">
-                          {roundedWouldTakeAgain != null &&
-                          roundedWouldTakeAgain >= 0 &&
-                          numRatings > 0
-                            ? `${roundedWouldTakeAgain}%`
-                            : "N/A"}
-                        </span>
-                        <span className="metric-sub">Student approval</span>
-                      </div>
-
-                      <div className="rmp-metric total-ratings">
-                        <span className="metric-label">Reviews</span>
-                        <span className="metric-value">
-                          {roundedWouldTakeAgain != null ? numRatings : "N/A"}
-                        </span>
-                        <span className="metric-sub">Total reviews</span>
-                      </div>
-                    </div>
-
-                    {/* top tags */}
-                    {topTags.length > 0 && (
-                      <div className="rmp-tags">
-                        <span className="tags-label">Top Tags</span>
-                        <div className="tags-grid">
-                          {topTags.slice(0, 5).map((tag) => (
-                            <span
-                              className="tag-chip"
-                              key={tag.id || tag.legacyId || Math.random()}
-                            >
-                              <span className="tag-name">
-                                {tag.tagName.length > 20
-                                  ? tag.tagName.substring(0, 20) + "..."
-                                  : tag.tagName}
-                              </span>
-                              <span className="tag-count">{tag.tagCount}</span>
-                            </span>
-                          ))}
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                ) : (
-                  // empty state
-                  <div className="rmp-card empty">
-                    <div className="rmp-card-header">
-                      <h4>Rate My Professors</h4>
-                    </div>
-                    <p className="rmp-empty">
-                      Rate My Professors data not available.
-                    </p>
-                  </div>
-                )}
               </div>
-            )}
-          </div>
-        </div>
-      )}
+            </div>
+          </Draggable>,
+          document.body,
+        )}
     </div>
   );
 }

--- a/src/react/styles/index.css
+++ b/src/react/styles/index.css
@@ -183,36 +183,6 @@
 
 /* Modal properties */
 
-.prof-info-modal-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  /* overlay sits at 1000, active (1001) sits above it, inactive (999) are below it */
-  z-index: 1000;
-  background: rgba(15, 23, 42, 0.45);
-  display: flex;
-  justify-content: flex-end;
-  align-items: flex-start;
-  padding: 32px 36px;
-  animation: fadeIn 0.3s ease-out;
-}
-
-.prof-info-modal {
-  background: #ffffff;
-  border-radius: 16px;
-  width: min(420px, 90vw);
-  max-height: calc(100vh - 96px);
-  overflow-y: auto;
-  padding: 28px 32px;
-  box-shadow:
-    0 18px 45px rgba(15, 23, 42, 0.28),
-    0 4px 16px rgba(15, 23, 42, 0.12);
-  border: 1px solid rgba(226, 232, 240, 0.8);
-  position: relative;
-}
-
 .prof-info-title {
   margin: 0;
   font-size: 20px;
@@ -691,21 +661,33 @@
   }
 }
 
+@media (min-width: 1200px) {
+  .prof-sticky-card {
+    width: 420px;
+    max-height: 700px;
+    border-radius: 24px;
+  }
+
+  .prof-sticky-content {
+    padding: 28px;
+  }
+
+  .prof-info-title {
+    font-size: 1.4rem;
+  }
+
+  .campus-card,
+  .rmp-card {
+    padding: 28px;
+    margin-bottom: 24px;
+  }
+}
+
 /*
  * ==========================================
  * KEYFRAME ANIMATIONS
  * ==========================================
  */
-@keyframes prof-info-fade-in {
-  from {
-    opacity: 0;
-    transform: translateY(-4px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
 
 @keyframes fadeIn {
   from {

--- a/src/react/styles/index.css
+++ b/src/react/styles/index.css
@@ -65,7 +65,7 @@
 
 /* sticky card container (draggable) */
 .prof-sticky-card {
-  position: fixed;
+  position: relative;
   width: 360px;
   max-height: 600px;
   background: #f8fafc;

--- a/src/react/styles/index.css
+++ b/src/react/styles/index.css
@@ -183,36 +183,6 @@
 
 /* Modal properties */
 
-.prof-info-modal-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  /* overlay sits at 1000, active (1001) sits above it, inactive (999) are below it */
-  z-index: 1000;
-  background: rgba(15, 23, 42, 0.45);
-  display: flex;
-  justify-content: flex-end;
-  align-items: flex-start;
-  padding: 32px 36px;
-  animation: fadeIn 0.3s ease-out;
-}
-
-.prof-info-modal {
-  background: #ffffff;
-  border-radius: 16px;
-  width: min(420px, 90vw);
-  max-height: calc(100vh - 96px);
-  overflow-y: auto;
-  padding: 28px 32px;
-  box-shadow:
-    0 18px 45px rgba(15, 23, 42, 0.28),
-    0 4px 16px rgba(15, 23, 42, 0.12);
-  border: 1px solid rgba(226, 232, 240, 0.8);
-  position: relative;
-}
-
 .prof-info-title {
   margin: 0;
   font-size: 20px;
@@ -761,21 +731,33 @@
   }
 }
 
+@media (min-width: 1200px) {
+  .prof-sticky-card {
+    width: 420px;
+    max-height: 700px;
+    border-radius: 24px;
+  }
+
+  .prof-sticky-content {
+    padding: 28px;
+  }
+
+  .prof-info-title {
+    font-size: 1.4rem;
+  }
+
+  .campus-card,
+  .rmp-card {
+    padding: 28px;
+    margin-bottom: 24px;
+  }
+}
+
 /*
  * ==========================================
  * KEYFRAME ANIMATIONS
  * ==========================================
  */
-@keyframes prof-info-fade-in {
-  from {
-    opacity: 0;
-    transform: translateY(-4px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
 
 @keyframes fadeIn {
   from {

--- a/src/react/styles/index.css
+++ b/src/react/styles/index.css
@@ -14,7 +14,6 @@
   position: absolute;
   top: 15px;
   right: 18px; /* Distance from the right of the panel */
-
   z-index: 999;
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial,
@@ -32,7 +31,6 @@
   font-weight: 600;
   padding: 0;
   margin: 0;
-
   display: flex;
   align-items: center;
   justify-content: center;
@@ -40,17 +38,14 @@
   height: 28px;
   border-radius: 50%;
   border: none;
-
   background-color: #00508f;
   color: #ffffff;
   cursor: pointer;
-
   /* MUI-style shadow */
   box-shadow:
     0 2px 2px 0 rgba(0, 0, 0, 0.14),
     0 3px 1px -2px rgba(0, 0, 0, 0.12),
     0 1px 5px 0 rgba(0, 0, 0, 0.2);
-
   transition: all 0.2s ease-in-out;
 }
 
@@ -66,6 +61,124 @@
     0 4px 5px -2px rgba(0, 0, 0, 0.2),
     0 7px 10px 1px rgba(0, 0, 0, 0.14),
     0 2px 16px 1px rgba(0, 0, 0, 0.12);
+}
+
+/* sticky card container (draggable) */
+.prof-sticky-card {
+  position: fixed;
+  width: 360px;
+  max-height: 600px;
+  background: #f8fafc;
+  border-radius: 20px;
+  box-shadow:
+    0 20px 40px rgba(0, 0, 0, 0.2),
+    0 0 0 1px rgba(0, 0, 0, 0.05);
+  display: flex;
+  flex-direction: column;
+  font-family: "Roboto", sans-serif;
+  z-index: 10000;
+  overflow: hidden;
+  animation: fadeIn 0.2s ease-out;
+
+  /* default cursor (pinned state) */
+  cursor: default;
+}
+
+/* when dragging is unlocked */
+.prof-sticky-card.draggable-active {
+  cursor: grab;
+  box-shadow:
+    0 20px 40px rgba(0, 0, 0, 0.2),
+    0 0 0 2px #00508f; /* Blue border when moving */
+}
+
+.prof-sticky-card.draggable-active:active {
+  cursor: grabbing;
+}
+
+/* header */
+.prof-sticky-header {
+  background-color: white;
+  padding: 16px 24px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid #f1f5f9;
+  user-select: none;
+}
+
+.prof-info-title {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 800;
+  color: #0f172a;
+}
+
+.header-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+/* lock button */
+.prof-lock-btn {
+  background: #f1f5f9;
+  border: none;
+  border-radius: 50%;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: #64748b;
+  transition: all 0.2s;
+}
+.prof-lock-btn:hover {
+  background: #e2e8f0;
+  color: #334155;
+}
+.prof-lock-btn.unlocked {
+  color: #00508f;
+  background: #e0f2fe;
+}
+
+/* close button */
+.prof-info-close {
+  background: #f1f5f9;
+  border: none;
+  border-radius: 50%;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #64748b;
+  cursor: pointer;
+  font-weight: bold;
+  font-size: 14px;
+  transition: all 0.2s;
+}
+.prof-info-close:hover {
+  background: #fee2e2;
+  color: #ef4444;
+}
+
+/* scrollable content area */
+.prof-sticky-content {
+  padding: 20px;
+  overflow-y: auto;
+  flex-grow: 1;
+  background-color: #f8fafc;
+}
+
+/* custom scrollbar for popup */
+.prof-sticky-content::-webkit-scrollbar {
+  width: 6px;
+}
+.prof-sticky-content::-webkit-scrollbar-thumb {
+  background: #cbd5e1;
+  border-radius: 3px;
 }
 
 /* Modal properties */
@@ -98,14 +211,6 @@
     0 4px 16px rgba(15, 23, 42, 0.12);
   border: 1px solid rgba(226, 232, 240, 0.8);
   position: relative;
-}
-
-.prof-info-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 16px;
-  margin-bottom: 16px;
 }
 
 .prof-info-title {
@@ -644,6 +749,15 @@
   .rmp-section {
     border-left: none;
     border-top: 8px solid #e1e4e8;
+  }
+}
+
+@media (max-width: 480px) {
+  .prof-sticky-card {
+    /* On mobile, shrink width to fit 90% of screen */
+    width: 90vw !important;
+    max-height: 80vh;
+    font-size: 14px;
   }
 }
 

--- a/src/react/styles/index.css
+++ b/src/react/styles/index.css
@@ -14,7 +14,6 @@
   position: absolute;
   top: 15px;
   right: 18px; /* Distance from the right of the panel */
-
   z-index: 999;
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial,
@@ -32,7 +31,6 @@
   font-weight: 600;
   padding: 0;
   margin: 0;
-
   display: flex;
   align-items: center;
   justify-content: center;
@@ -40,17 +38,14 @@
   height: 28px;
   border-radius: 50%;
   border: none;
-
   background-color: #00508f;
   color: #ffffff;
   cursor: pointer;
-
   /* MUI-style shadow */
   box-shadow:
     0 2px 2px 0 rgba(0, 0, 0, 0.14),
     0 3px 1px -2px rgba(0, 0, 0, 0.12),
     0 1px 5px 0 rgba(0, 0, 0, 0.2);
-
   transition: all 0.2s ease-in-out;
 }
 
@@ -66,6 +61,124 @@
     0 4px 5px -2px rgba(0, 0, 0, 0.2),
     0 7px 10px 1px rgba(0, 0, 0, 0.14),
     0 2px 16px 1px rgba(0, 0, 0, 0.12);
+}
+
+/* sticky card container (draggable) */
+.prof-sticky-card {
+  position: fixed;
+  width: 360px;
+  max-height: 600px;
+  background: #f8fafc;
+  border-radius: 20px;
+  box-shadow:
+    0 20px 40px rgba(0, 0, 0, 0.2),
+    0 0 0 1px rgba(0, 0, 0, 0.05);
+  display: flex;
+  flex-direction: column;
+  font-family: "Roboto", sans-serif;
+  z-index: 10000;
+  overflow: hidden;
+  animation: fadeIn 0.2s ease-out;
+
+  /* default cursor (pinned state) */
+  cursor: default;
+}
+
+/* when dragging is unlocked */
+.prof-sticky-card.draggable-active {
+  cursor: grab;
+  box-shadow:
+    0 20px 40px rgba(0, 0, 0, 0.2),
+    0 0 0 2px #00508f; /* Blue border when moving */
+}
+
+.prof-sticky-card.draggable-active:active {
+  cursor: grabbing;
+}
+
+/* header */
+.prof-sticky-header {
+  background-color: white;
+  padding: 16px 24px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid #f1f5f9;
+  user-select: none;
+}
+
+.prof-info-title {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 800;
+  color: #0f172a;
+}
+
+.header-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+/* lock button */
+.prof-lock-btn {
+  background: #f1f5f9;
+  border: none;
+  border-radius: 50%;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: #64748b;
+  transition: all 0.2s;
+}
+.prof-lock-btn:hover {
+  background: #e2e8f0;
+  color: #334155;
+}
+.prof-lock-btn.unlocked {
+  color: #00508f;
+  background: #e0f2fe;
+}
+
+/* close button */
+.prof-info-close {
+  background: #f1f5f9;
+  border: none;
+  border-radius: 50%;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #64748b;
+  cursor: pointer;
+  font-weight: bold;
+  font-size: 14px;
+  transition: all 0.2s;
+}
+.prof-info-close:hover {
+  background: #fee2e2;
+  color: #ef4444;
+}
+
+/* scrollable content area */
+.prof-sticky-content {
+  padding: 20px;
+  overflow-y: auto;
+  flex-grow: 1;
+  background-color: #f8fafc;
+}
+
+/* custom scrollbar for popup */
+.prof-sticky-content::-webkit-scrollbar {
+  width: 6px;
+}
+.prof-sticky-content::-webkit-scrollbar-thumb {
+  background: #cbd5e1;
+  border-radius: 3px;
 }
 
 /* Modal properties */
@@ -98,14 +211,6 @@
     0 4px 16px rgba(15, 23, 42, 0.12);
   border: 1px solid rgba(226, 232, 240, 0.8);
   position: relative;
-}
-
-.prof-info-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 16px;
-  margin-bottom: 16px;
 }
 
 .prof-info-title {
@@ -574,6 +679,15 @@
   .rmp-section {
     border-left: none;
     border-top: 8px solid #e1e4e8;
+  }
+}
+
+@media (max-width: 480px) {
+  .prof-sticky-card {
+    /* On mobile, shrink width to fit 90% of screen */
+    width: 90vw !important;
+    max-height: 80vh;
+    font-size: 14px;
   }
 }
 


### PR DESCRIPTION
## Related Tasks/Dependencies
- AMP 93 (https://ivankuria.atlassian.net/browse/AMP-93)


## Overview/Premise
- Implemented draggable modal
- Implemented fuzzy matching for `getUIDFromJSON`

### Example of fuzzy matching success
<img width="458" height="98" alt="image" src="https://github.com/user-attachments/assets/6777cb46-0227-4b32-82ef-64015d2c11eb" />

### Example of new popup UI
<img width="937" height="774" alt="image" src="https://github.com/user-attachments/assets/baa0ed62-6863-4f97-8942-44fac0e9b376" />


## Changes
- Implemented a draggable functionality for the popup
  - Changed some CSS to match the functionality, tried to keep as close to the original as possible
  - Kept as undraggable/locked by default
    - Click on lock icon to make the popup draggable
  - Implemented a algo to place the card to the right of the info button if possible
    - depends on size of viewport
- Changed cache lifetime from 1 day to 1 week due to observing AMP/RMP data only changing periodically

## Concerns/Notes
- Need to add testing for new draggable functionality 